### PR TITLE
Add proxy support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
             "version": "0.0.5",
             "dependencies": {
                 "got": "11.8.5",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.4",
                 "iconv-lite": "0.6.3"
             },
             "devDependencies": {
@@ -1120,6 +1122,19 @@
                 "node-pre-gyp": "bin/node-pre-gyp"
             }
         },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/@node-red/editor-api": {
             "version": "3.1.7",
             "resolved": "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-3.1.7.tgz",
@@ -1562,6 +1577,42 @@
             "engines": {
                 "node": ">=10.19.0"
             }
+        },
+        "node_modules/@node-red/nodes/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/@node-red/nodes/node_modules/https-proxy-agent/node_modules/debug": {
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+            "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@node-red/nodes/node_modules/https-proxy-agent/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "node_modules/@node-red/nodes/node_modules/json-schema-traverse": {
             "version": "1.0.0",
@@ -4020,7 +4071,6 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -5867,18 +5917,26 @@
             }
         },
         "node_modules/http-proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-            "dev": true,
-            "optional": true,
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dependencies": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
+            }
+        },
+        "node_modules/http-proxy-agent/node_modules/agent-base": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/http2-wrapper": {
@@ -5894,16 +5952,26 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dev": true,
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
             "dependencies": {
-                "agent-base": "6",
+                "agent-base": "^7.0.2",
                 "debug": "4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
+            }
+        },
+        "node_modules/https-proxy-agent/node_modules/agent-base": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/humanize-ms": {
@@ -6677,6 +6745,35 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/make-fetch-happen/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/make-fetch-happen/node_modules/lru-cache": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -7239,8 +7336,7 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/multer": {
             "version": "1.4.5-lts.1",
@@ -11457,6 +11553,18 @@
                 "rimraf": "^3.0.2",
                 "semver": "^7.3.5",
                 "tar": "^6.1.11"
+            },
+            "dependencies": {
+                "https-proxy-agent": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+                    "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "6",
+                        "debug": "4"
+                    }
+                }
             }
         },
         "@node-red/editor-api": {
@@ -11814,6 +11922,33 @@
                     "requires": {
                         "quick-lru": "^5.1.1",
                         "resolve-alpn": "^1.2.0"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+                    "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "6",
+                        "debug": "4"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "4.3.5",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+                            "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+                            "dev": true,
+                            "requires": {
+                                "ms": "2.1.2"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.1.2",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                            "dev": true
+                        }
                     }
                 },
                 "json-schema-traverse": {
@@ -13760,7 +13895,6 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -15147,15 +15281,22 @@
             }
         },
         "http-proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-            "dev": true,
-            "optional": true,
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "requires": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "dependencies": {
+                "agent-base": {
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+                    "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+                    "requires": {
+                        "debug": "^4.3.4"
+                    }
+                }
             }
         },
         "http2-wrapper": {
@@ -15168,13 +15309,22 @@
             }
         },
         "https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dev": true,
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
             "requires": {
-                "agent-base": "6",
+                "agent-base": "^7.0.2",
                 "debug": "4"
+            },
+            "dependencies": {
+                "agent-base": {
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+                    "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+                    "requires": {
+                        "debug": "^4.3.4"
+                    }
+                }
             }
         },
         "humanize-ms": {
@@ -15748,6 +15898,29 @@
                 "ssri": "^8.0.0"
             },
             "dependencies": {
+                "http-proxy-agent": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+                    "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "@tootallnate/once": "1",
+                        "agent-base": "6",
+                        "debug": "4"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+                    "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "agent-base": "6",
+                        "debug": "4"
+                    }
+                },
                 "lru-cache": {
                     "version": "6.0.0",
                     "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -16193,8 +16366,7 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "multer": {
             "version": "1.4.5-lts.1",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
     "description": "Node-RED file nodes packaged for FlowFuse",
     "main": "index.js",
     "scripts": {
-        "test": "npm run test:files && npm run test:memory",
+        "test": "npm run test:files && npm run test:memory && npm run test:utils",
         "test:memory": "mocha 'test/memory_spec.js' --timeout 5000",
         "test:files": "mocha 'test/file_spec.js' --timeout 5000",
+        "test:utils": "mocha 'test/utils_spec.js' --timeout 5000",
         "lint": "eslint -c .eslintrc *.js",
         "lint:fix": "eslint -c .eslintrc *.js --fix"
     },
@@ -34,7 +35,9 @@
     "homepage": "https://github.com/FlowFuse/nr-file-nodes#readme",
     "dependencies": {
         "got": "11.8.5",
-        "iconv-lite": "0.6.3"
+        "iconv-lite": "0.6.3",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.4"
     },
     "engines": {
         "node": ">=16.x"

--- a/test/file_spec.js
+++ b/test/file_spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+const should = require('should')
 const path = require('path')
 const fs = require('fs-extra')
 const os = require('os')
@@ -29,6 +30,7 @@ const testFilesDir = path.join('test', 'resources')
 const testFilesRealDir = path.join(cwd, testFilesDir, TeamID, ProjectID)
 const setup = require('./setup')
 const util = require('util')
+const utils = require('../utils.js')
 
 // Setup the test environment
 const driverType = 'localfs'
@@ -1891,6 +1893,115 @@ describe('File Nodes with file backed filer-server', function () {
 
             it('should read in a file with "tis620" encoding', function (done) {
                 checkReadWithEncoding('tis620', 'test', done)
+            })
+        })
+    })
+    describe.only('Proxy', function () {
+        const { HttpProxyAgent } = require('http-proxy-agent')
+        const { HttpsProxyAgent } = require('https-proxy-agent')
+        const relativePathToFile = '50-file-test-file.txt'
+        const resourcesDir = testFilesDir
+        try {
+            fs.mkdirSync(resourcesDir)
+        } catch (error) {
+            // ignore
+        }
+        const fileToTest = relativePathToFile
+
+        beforeEach(function (done) {
+            process.env.TEST_FILE = fileToTest
+            RED.settings.flowforge = {
+                teamID: TeamID,
+                projectID: ProjectID,
+                fileStore: {
+                    url: fileServerURL,
+                    token: 'test-token-1'
+                }
+            }
+            helper.startServer(done)
+        })
+
+        afterEach(function (done) {
+            delete RED.settings.fileWorkingDirectory
+            fs.removeSync(path.join(resourcesDir, 'file-out-node'))
+            helper.unload().then(function () {
+                // fs.unlinkSync(fileToTest);
+                helper.stopServer(done)
+            })
+            delete process.env.TEST_FILE
+            sinon.restore()
+        })
+        it('should not load proxy agents if env vars are not set', function (done) {
+            // spy utils.getHTTPProxyAgent to check if it is called and what it returns
+            const spy = sinon.spy(utils, 'getHTTPProxyAgent')
+            process.env.http_proxy = ''
+            process.env.https_proxy = ''
+            const flow = [{ id: 'fileInNode1', type: 'file in', name: 'fileInNode', filename: 'test', format: 'utf8' }]
+            helper.load(fileNode, flow, function () {
+                try {
+                    spy.called.should.be.true()
+                    spy.returned({}).should.be.true()
+                    done()
+                } catch (error) {
+                    done(error)
+                }
+            })
+        })
+        it('should load http proxy agent if http_proxy env var is set', function (done) {
+            // spy utils.getHTTPProxyAgent to check if it is called and what it returns
+            const spy = sinon.spy(utils, 'getHTTPProxyAgent')
+            process.env.http_proxy = 'http://localhost:8080'
+            process.env.https_proxy = ''
+            const flow = [{ id: 'fileInNode1', type: 'file in', name: 'fileInNode', filename: 'test', format: 'utf8' }]
+            helper.load(fileNode, flow, function () {
+                try {
+                    spy.called.should.be.true()
+                    const agent = spy.returnValues?.[0]
+                    should(agent).not.be.empty()
+                    agent.should.have.a.property('http').and.be.an.instanceOf(HttpProxyAgent)
+                    should(agent.https).be.undefined()
+                    done()
+                } catch (error) {
+                    done(error)
+                }
+            })
+        })
+        it('should load https proxy agent if https_proxy env var is set', function (done) {
+            // spy utils.getHTTPProxyAgent to check if it is called and what it returns
+            const spy = sinon.spy(utils, 'getHTTPProxyAgent')
+            process.env.http_proxy = ''
+            process.env.https_proxy = 'http://localhost:8080'
+            const flow = [{ id: 'fileInNode1', type: 'file in', name: 'fileInNode', filename: 'test', format: 'utf8' }]
+            helper.load(fileNode, flow, function () {
+                try {
+                    spy.called.should.be.true()
+                    const agent = spy.returnValues?.[0]
+                    should(agent).not.be.empty()
+                    agent.should.have.a.property('https').and.be.an.instanceOf(HttpsProxyAgent)
+                    should(agent.http).be.undefined()
+                    done()
+                } catch (error) {
+                    done(error)
+                }
+            })
+        })
+        it('should load both http and https proxy agents if both env vars are set', function (done) {
+            // spy utils.getHTTPProxyAgent to check if it is called and what it returns
+            const spy = sinon.spy(utils, 'getHTTPProxyAgent')
+            process.env.http_proxy = 'http://localhost:8080'
+            process.env.https_proxy = 'http://localhost:8081'
+            const flow = [{ id: 'fileInNode1', type: 'file in', name: 'fileInNode', filename: 'test', format: 'utf8' }]
+            helper.load(fileNode, flow, function () {
+                try {
+                    spy.called.should.be.true()
+                    const agent = spy.returnValues?.[0]
+                    should(agent).not.be.empty()
+                    agent.should.have.a.property('http').and.be.an.instanceOf(HttpProxyAgent)
+                    agent.should.have.a.property('https').and.be.an.instanceOf(HttpsProxyAgent)
+                    done()
+                } catch (error) {
+                    done(error)
+                }
             })
         })
     })

--- a/test/file_spec.js
+++ b/test/file_spec.js
@@ -1896,7 +1896,7 @@ describe('File Nodes with file backed filer-server', function () {
             })
         })
     })
-    describe.only('Proxy', function () {
+    describe('Proxy', function () {
         const { HttpProxyAgent } = require('http-proxy-agent')
         const { HttpsProxyAgent } = require('https-proxy-agent')
         const relativePathToFile = '50-file-test-file.txt'

--- a/test/utils_spec.js
+++ b/test/utils_spec.js
@@ -1,0 +1,55 @@
+const should = require('should') // eslint-disable-line no-unused-vars
+const utils = require('../utils.js')
+
+describe('utils', () => {
+    describe('getHTTPProxyAgent', function () {
+        const HttpProxyAgent = require('http-proxy-agent').HttpProxyAgent
+        const HttpsProxyAgent = require('https-proxy-agent').HttpsProxyAgent
+
+        it('should return an agent object without any http or https proxy when env vars are not set', function () {
+            process.env.http_proxy = ''
+            process.env.https_proxy = ''
+            const agent = utils.getHTTPProxyAgent()
+            agent.should.not.have.property('http')
+            agent.should.not.have.property('https')
+        })
+        it('should return an agent object with http property when http_proxy is set', function () {
+            process.env.http_proxy = 'http://proxy:8080'
+            process.env.https_proxy = ''
+            const agent = utils.getHTTPProxyAgent()
+            agent.should.have.property('http').instanceOf(HttpProxyAgent)
+            agent.http.should.have.property('proxy')
+            agent.http.proxy.should.have.property('hostname', 'proxy')
+            agent.http.proxy.should.have.property('port', '8080')
+        })
+        it('should return an agent object with https property when https_proxy is set', function () {
+            process.env.http_proxy = ''
+            process.env.https_proxy = 'http://proxy:8080'
+            const agent = utils.getHTTPProxyAgent()
+            agent.should.have.property('https').instanceOf(HttpsProxyAgent)
+            agent.https.should.have.property('proxy')
+            agent.https.proxy.should.have.property('hostname', 'proxy')
+            agent.https.proxy.should.have.property('port', '8080')
+        })
+        it('should return an agent object with both http and https properties', function () {
+            process.env.http_proxy = 'http://proxy:8080'
+            process.env.https_proxy = 'http://proxy:8081'
+            const agent = utils.getHTTPProxyAgent()
+            agent.should.have.property('http').instanceOf(HttpProxyAgent)
+            agent.http.should.have.property('proxy')
+            agent.http.proxy.should.have.property('hostname', 'proxy')
+            agent.http.proxy.should.have.property('port', '8080')
+            agent.should.have.property('https').instanceOf(HttpsProxyAgent)
+            agent.https.should.have.property('proxy')
+            agent.https.proxy.should.have.property('hostname', 'proxy')
+            agent.https.proxy.should.have.property('port', '8081')
+        })
+        it('should set proxy options', function () {
+            process.env.http_proxy = 'http://proxy:8080'
+            process.env.https_proxy = 'http://proxy:8081'
+            const agent = utils.getHTTPProxyAgent({ timeout: 2345 })
+            agent.http.connectOpts.should.have.property('timeout', 2345)
+            agent.https.connectOpts.should.have.property('timeout', 2345)
+        })
+    })
+})

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,21 @@
+module.exports = {
+    getHTTPProxyAgent
+}
+
+/**
+ * Get proxy agents for HTTP and/or HTTPS connections
+ * @param {import('http').AgentOptions} proxyOptions - proxy options
+ * @returns {{http: import('http-proxy-agent').HttpProxyAgent | undefined, https: import('https-proxy-agent').HttpsProxyAgent | undefined}}
+ */
+function getHTTPProxyAgent (proxyOptions) {
+    const agent = {}
+    if (process.env.http_proxy) {
+        const HttpAgent = require('http-proxy-agent').HttpProxyAgent
+        agent.http = new HttpAgent(process.env.http_proxy, proxyOptions)
+    }
+    if (process.env.https_proxy) {
+        const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
+        agent.https = new HttpsAgent(process.env.https_proxy, proxyOptions)
+    }
+    return agent
+}

--- a/vfs.js
+++ b/vfs.js
@@ -15,7 +15,8 @@
  **/
 
 const Stream = require('stream')
-const got = require('got')
+const utils = require('./utils')
+const got = require('got').default
 
 module.exports = function (RED, _teamID, _projectID, _token) {
     'use strict'
@@ -36,7 +37,8 @@ module.exports = function (RED, _teamID, _projectID, _token) {
         },
         retry: {
             limit: 0
-        }
+        },
+        agent: utils.getHTTPProxyAgent({ timeout: 3000 })
     })
 
     const normaliseError = (err, filename) => {


### PR DESCRIPTION
closes #55 

## Description

* adds dependencies 
    * `http-proxy-agent`
    * `https-proxy-agent`
* adds utils.getHTTPProxyAgent and appropriate unit tests
* updates `vfs.js` to call `utils.getHTTPProxyAgent` and apply proxy agent

### Tests added

#### `test/file_spec.js`
```
  File Nodes with file backed filer-server
    Proxy
      ✔ should not load proxy agents if env vars are not set
      ✔ should load http proxy agent if http_proxy env var is set
      ✔ should load https proxy agent if https_proxy env var is set
      ✔ should load both http and https proxy agents if both env vars are set

  4 passing (1s)
```
#### `test/utils_spec.js` (new file)
```
  utils
    getHTTPProxyAgent
      ✔ should return an agent object without any http or https proxy when env vars are not set
      ✔ should return an agent object with http property when http_proxy is set
      ✔ should return an agent object with https property when https_proxy is set
      ✔ should return an agent object with both http and https properties
      ✔ should set proxy options


  5 passing (22ms)
```  

## Related Issue(s)

#55
https://github.com/FlowFuse/device-agent/issues/268

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

